### PR TITLE
define output type in example config

### DIFF
--- a/examples/certstream/config.json
+++ b/examples/certstream/config.json
@@ -1,5 +1,6 @@
 {
   "input": "CertStream",
+  "output": "File",
   "fileConfig": {
       "outputFile": "/tmp/out"
   },


### PR DESCRIPTION
errors without this